### PR TITLE
Fix: update sphinx-favicon to sphinx_favicon

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -39,7 +39,7 @@ extensions = [
     'sphinxcontrib.platformpicker',
     'sphinxcontrib.asciinema',
     'sphinxcontrib.youtube',
-    'sphinx-favicon',
+    'sphinx_favicon',
     'sphinxext.opengraph',
     'ablog',
 ]


### PR DESCRIPTION
The gh-pages-build run [Fix link to GDB manual #31](https://github.com/blackmagic-debug/black-magic-org/actions/runs/4587408990/jobs/8100891082) failed with:
```
Extension error:
Could not import extension sphinx-favicon (exception: No module named 'sphinx-favicon')
```

According to https://pypi.org/project/sphinx-favicon/

> Between v0.2 and v1.0, the module name of the extension changed to better conform with Python standards. Please update the name used in the extension list of your conf.py from sphinx-favicon to sphinx_favicon!

The Setup Sphinx part step of the build shows that sphinx-favicon-1.0.1 is used.

This pull request therefore updates the `sphinx-favicon` to `sphinx_favicon`