### PR TITLE
Fix warning: update actions from v2 to v3, to use node16 instead of node12

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: '3.10'
       - name: Setup Environment
@@ -22,7 +22,7 @@ jobs:
           echo "$HOME/.local/bin:$PATH" >> $GITHUB_PATH
           echo "GITHUB_WORKSPACE=\"`pwd`\"" >> $GITHUB_ENV
       - name: Checkout Black Magic Debug Website Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           lfs: true
           submodules: true
@@ -38,7 +38,7 @@ jobs:
         run: sphinx-build -b html . build
       - name: Deploy
         if: success()
-        uses: crazy-max/ghaction-github-pages@v2
+        uses: crazy-max/ghaction-github-pages@v3
         with:
           target_branch: gh-pages
           build_dir: build


### PR DESCRIPTION
The gh-pages-build run [misc: spelling corrections #30](
https://github.com/blackmagic-debug/black-magic-org/actions/runs/4180757473) shows the following warning:
> [build gh-pages](https://github.com/blackmagic-debug/black-magic-org/actions/runs/4180757473/jobs/7242045299)
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/setup-python@v2, actions/checkout@v2, crazy-max/ghaction-github-pages@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

This pull request updates the the following actions from v2 to v3, to use node16 instead of node12:
- actions/setup-python
- actions/checkout
- crazy-max/ghaction-github-pages
