### PR TITLE
sphinx: This adds the missing ablog prefixes.

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -88,8 +88,8 @@ html_sidebars = {
     '**': [
         'about.html',
         'navigation.html',
-        'recentposts.html',
-        'archives.html',
+        'ablog/recentposts.html',
+        'ablog/archives.html',
         'relations.html',
         'searchbox.html',
         'donate.html',


### PR DESCRIPTION
The ablog template is warning that using recenposts.html and archives.html directly without the ablog prefix is depricated. This patch fixes this.