### PR TITLE
Feature: update Black Pill v2 to Black Pill F4

### DIFF
--- a/hardware.md
+++ b/hardware.md
@@ -126,6 +126,10 @@ Instructions to restore an ST-Link v2 with recent original ST firmware can be fo
 
 You can run the Black Magic Probe firmware on the "target" processor of an ST F4 discovery board. This is useful if you want to bootstrap your F4 Discovery board ST-Link programmer without having any other means of programming it.
 
+## Black Pill F4: F401CC / F401CE / F411CE
+
+The black magic firmware can be built and flashed to Black Pill boards with STM32F401CC, STM32F401CE and STM32F411CE microcontrollers. Since these microcontrollers have slightly different hardware specifications in terms of flash, sram and clock frequency, each microcontroller has its own platform. The platforms share [common code](https://github.com/blackmagic-debug/blackmagic/tree/main/src/platforms/common/blackpill-f4). This page also contains build and firmware upgrade instructions.
+
 ## SW Link
 
 This target is the programmer integrated on the STM8S Discovery board.

--- a/index.md
+++ b/index.md
@@ -145,10 +145,10 @@ The official Black Magic Probe hardware is available from these distributors in 
 ## Other Hardware supported by Black Magic Debug:
 
  * ST-Link v2, v2.1 and Blue Pill. See [stlink](https://github.com/blackmagic-debug/blackmagic/tree/master/src/platforms/stlink)
- * ST_Link v3. See [stlinkv3](https://github.com/blackmagic-debug/blackmagic/tree/main/src/platforms/stlinkv3) 
+ * ST-Link v3. See [stlinkv3](https://github.com/blackmagic-debug/blackmagic/tree/main/src/platforms/stlinkv3) 
  * STM8S Discovery (ST-Link V1). See [swlink](https://github.com/blackmagic-debug/blackmagic/tree/main/src/platforms/swlink)
  * F4 Discovery (STM32F407). See [f4discovery](https://github.com/blackmagic-debug/blackmagic/tree/main/src/platforms/f4discovery)
- * Black Pill v2 (STM32F411). See [blackpillv2](https://github.com/blackmagic-debug/blackmagic/tree/main/src/platforms/blackpillv2)
+ * Black Pill F4 (STM32F401CC/STM32F401CE/STM32F411CE). See [blackpill-f401cc](https://github.com/blackmagic-debug/blackmagic/tree/main/src/platforms/blackpill-f401cc), [blackpill-f401ce](https://github.com/blackmagic-debug/blackmagic/tree/main/src/platforms/blackpill-f401ce), [blackpill-f411ce](https://github.com/blackmagic-debug/blackmagic/tree/main/src/platforms/blackpill-f411ce)
  * TI LaunchPad Tiva C onboard programmer. See [launchpad-icdi](https://github.com/blackmagic-debug/blackmagic/tree/main/src/platforms/launchpad-icdi)
  * [HydraBus](https://hydrabus.com/). See [hydrabus](https://github.com/blackmagic-debug/blackmagic/tree/main/src/platforms/hydrabus)
  * [96Boards Carbon](https://www.96boards.org/product/carbon/). See [96_carbon](https://github.com/blackmagic-debug/blackmagic/tree/main/src/platforms/96b_carbon)


### PR DESCRIPTION
update Black Pill v2 to Black Pill F4, to make the website consistent with the changes done in https://github.com/blackmagic-debug/blackmagic/pull/1491.

## Detailed description

- update index page
  - update Black Pill v2 to Black Pill F4, and add links to respective platforms: blackpill-f401cc, blackpill-f401ce, blackpill-f411ce
  - fix typo in ST-Link v3
- update hardware page
  - add section on Black Pill F4 for the Black Pill boards with F401CC, F401CE, F411CE microcontrollers