### PR TITLE
Feature: Supported targets table

### DIFF
--- a/index.md
+++ b/index.md
@@ -12,6 +12,7 @@
 hardware
 getting-started
 upgrade
+supported-targets
 ```
 
 ```{toctree}

--- a/knowledge/faq.md
+++ b/knowledge/faq.md
@@ -5,15 +5,18 @@
 The official Black Magic Probe hardware is available from multiple vendors. An up to date list is kept on the [project main page](index.md#getting-hardware).
 
 ## Where can I find the BMP schematics?
+
  * [Black Magic Probe Mini v2.1](https://github.com/blackmagic-debug/blackmagic/wiki/files/bmpm_v2_1c_schematic.pdf)
  * [Black Magic Probe Mini v2.0](https://github.com/blackmagic-debug/blackmagic/wiki/files/bmpm_v2_0f_schematic.pdf)
  * [Black Magic Probe Mini](https://github.com/blackmagic-debug/blackmagic/wiki/files/blackmagic_mini.pdf)
  * [Original Black Magic Probe](https://github.com/blackmagic-debug/blackmagic/wiki/files/blackmagic-1.0.pdf)
 
 ## What are those JTAG/SWD connectors and cables?
+
 The JTAG/SWD connector is [FTSH-105-01-F-DV-K from Samtec](https://www.samtec.com/products/ftsh-105-01-f-dv-k) (Buy: [Digi-key](http://www.digikey.com/product-detail/en/FTSH-105-01-F-DV-K/FTSH-105-01-F-DV-K-ND/2649974), [1BitSquared](https://1bitsquared.com/products/jtag-swd-smd-connector)).
 
 The JTAG/SWD connector is a 0.05" (50mil/1.27mm) pitch, 2 row 10pin connector. The Samtec version is the only one that includes a keying shroud and does not occupy a large space on the PCB. There are other manufacturers that make connectors that can be used too. Here are a few options:
+
 * Amphenol FCI 20021121-00010C4LF unshrouded SMD (Buy: [Digi-key](https://www.digikey.com/product-detail/en/amphenol-fci/20021121-00010C4LF/609-3695-1-ND/2209147))
 * Amphenol FCI 20021111-00010T4LF unshrouded TH (Buy: [Digi-key](https://www.digikey.com/product-detail/en/amphenol-fci/20021111-00010T4LF/609-3712-ND/2209072))
 * Amphenol FCI 20021521-00010T1LF shrouded SMD (Buy: [Digi-key](https://www.digikey.com/product-detail/en/amphenol-fci/20021521-00010T1LF/609-4054-ND/2414951))
@@ -25,6 +28,7 @@ The JTAG/SWD connector is a 0.05" (50mil/1.27mm) pitch, 2 row 10pin connector. T
 The JTAG/SWD cable is [FFSD-05-D-xx.xx-01-N](https://www.samtec.com/products/ffsd-05-d-06.00-01-n) where the `x` stand for the length of the cable. Common length is 6 inches. (Buy: [Digi-key](https://www.digikey.com/product-detail/en/samtec-inc/FFSD-05-D-06.00-01-N/SAM8218-ND/1106577), [1BitSquared](https://1bitsquared.com/products/jtag-idc-cable))
 
 You can build your own JTAG/SWD ribbon cable using the following materials. (consider just an example there are many manufacturers making 1.27mm pitch IDC crimps and ribbons)
+
 * CNC Tech 3230-10-0103-00 IDC crimp with polarizing key. (Buy: [Digi-key](https://www.digikey.com/product-detail/en/cnc-tech/3230-10-0103-00/1175-1646-ND/3883463))
 * 3M 3756/10 0.025" (0.64mm) pitch 10 conductor flat ribbon cable. (Buy: [Digi-key](https://www.digikey.com/product-detail/en/3m/3756-10-100/ME10G-10-ND/5308218))
 
@@ -33,12 +37,14 @@ You can build your own JTAG/SWD ribbon cable using the following materials. (con
 The UART connector is Molex PicoBlade 0532610471. (Buy: [Digi-key](http://www.digikey.com/product-detail/en/0532610471/WM7622CT-ND/699109)).
 
 The UART cable can be built by hand using the following materials:
+
 * Molex PicoBlade 050079-8000 26-28AWG or 50058-8000 28-32AWG crimp sockets. (Buy: [Digi-key](https://www.digikey.com/product-detail/en/molex-llc/0500798000/WM1142CT-ND/467835) [Digi-key](https://www.digikey.com/product-detail/en/molex-llc/50058-8000/WM1775CT-ND/242897))
 * Molex PicoBlade 0510210400 housing (Buy: [Digi-key](https://www.digikey.com/product-detail/en/molex-llc/0510210400/WM1722-ND/242844))
 * Molex PicoBlade 0638271400 crimp tool (Buy: [Digi-key](https://www.digikey.com/product-detail/en/molex/0638271400/WM15815-ND/6577355)) (Warning: if you don't want to be very frustrated and destroy a lot of crimps skip trying to use cheaper options that claim to be compatible with the PicoBlade crimps, they are not.)
 * 26-32AWG wire of your choosing and whatever termination you need on the other side of the cable.
 
 The UART cable can also be built with pre crimped wires:
+
 * [Digi-key](https://www.digikey.com/short/08n0q938) Molex Picoblade pre-crimped cables, you can choose from all kinds of colors as well as doublesided or single sided crimps.
 * [1BitSquared](https://1bitsquared.com/products/picoblade-wire-kit) pre-crimped cable assortment
 
@@ -77,23 +83,32 @@ This solution is known to work on the LPC8xx/LPC11xx families of chips. If you a
 
 ## It's annoying to look up an always-changing device name on Linux.
 
-Use the bmp devices created under /dev/serial/by-id/usb-Black_Sp...-if00 or create a file named `/etc/udev/rules.d/99-blackmagic.rules` with the following contents:
+There are rules files provided in [the driver subdirectory of the main repository](https://github.com/blackmagic-debug/blackmagic/tree/main/driver).
+The readme walks through selection of an appropriate file and how to install them on your system.
 
-    # Black Magic Probe
-    # there are two connections, one for GDB and one for uart debugging
-      SUBSYSTEM=="tty", ATTRS{interface}=="Black Magic GDB Server", SYMLINK+="ttyBmpGdb"
-      SUBSYSTEM=="tty", ATTRS{interface}=="Black Magic UART Port", SYMLINK+="ttyBmpTarg"
+These provide entries for the following:
 
-Then unplug / replug the probe, or restart the computer.
+* `/dev/ttyBmpGdb` - The GDB serial interface for the most recently plugged in probe
+* `/dev/ttyBmpTarg` - The auxillary serial interface for the most recently plugged in probe
+* `/dev/ttyBmpGdb[serial]` - The GDB serial interface for the the probe identified by the serial number `[serial]`
+* `/dev/ttyBmpTarg[serial]` - The auxillary serial interface for the probe identified by the serial number `[serial]`
 
-Now you can access the probe at the stable names `/dev/ttyBmpGdb` and `/dev/ttyBmpTarg`.
+To illustrate an example of this, given a BMP with serial 8BB20695, one can expect by running the project's rule files
+to see this from a listing of `/dev/ttyBmp*`:
+
+```
+❯ ls /dev/ttyBmp*
+/dev/ttyBmpGdb  /dev/ttyBmpGdb8BB20695  /dev/ttyBmpTarg  /dev/ttyBmpTarg8BB20695
+```
 
 ## I want to connect to a Black Magic Probe on another machine.
 
 You can use stty and netcat.  On the machine with the probe connected, make a little TCP server on port 2000 with these commands:
 
-    stty -F /dev/ttyBmpGdb raw -onlcr -iexten -echo -echoe -echok -echoctl -echoke
-    nc -vkl -p 2000 > /dev/ttyBmpGdb < /dev/ttyBmbGdb
+```
+stty -F /dev/ttyBmpGdb raw -onlcr -iexten -echo -echoe -echok -echoctl -echoke
+nc -vkl -p 2000 > /dev/ttyBmpGdb < /dev/ttyBmbGdb
+```
 
 In gdb on the remote machine, connect with `target extended-remote hostname:2000` where `hostname` is the name or IP address of the machine running the probe.
 

--- a/knowledge/faq.md
+++ b/knowledge/faq.md
@@ -1,42 +1,5 @@
 # FAQ
 
-## What targets are currently supported?
-
-The Black Magic probe currently supports ARMv6-M and ARMv7-M architecture targets, specifically Cortex-M0, Cortex-M3 and Cortex-M4.
-Any device with these cores should work with possibly the exception flash memory programming.
-
-Memory map and flash programming are supported for these specific implementations:
-* `efm32.c`: Silicon Labs EFM32, EZR32
-* `kinetis.c`: Freescale Kinetis KL25, KL27, KL02
-* `lmi.c`: Texas Instruments: LM3S, TM4C
-* `lpc11xx.c`: NXP LPC8xx, LPC11xx
-* `lpc15xx.c`: NXP LPC15xx
-* `lpc17xx.c`:  NXP LPC17xx
-* `lpc43xx.c`: NXP LPC43xx
-* `lpc546xx.c`: NXP LPC546
-* `msp432.c`: MSP432P401
-* `nrf51.c`: Nordic nRF51, nRF52
-* `nxpke04.c`: Kinetis KE04
-* `renesas.c`: Renesas RA, R7FAxxx
-* `rp.c`: Raspberry RP20240
-* `sam3x.c`: Atmel SAM3N, SAM3X, SAM3S, SAM3U, SAM4S, SAMx7x
-* `sam4l.c`: Atmel SAM4L
-* `samd.c`: Atmel SAM D20, D21
-* `samdx5x.c`:Atmel SAMD5x/E5x
-* `samx5x.c`: Atmel SAMx5xqq
-* `stm32f1.c`: ST Microelectronics STM32F0, STM32F1, STM32F3
-* `stm32f4.c`: ST Microelectronics STM32F2, STM32F4, STM32F7
-* `stm32g0.c`: ST Microelectronics G0
-* `stm32h7.c`: ST Microelectronics H7
-* `stm32l0.c`: ST Microelectronics STM32L0, STM32L1
-* `stm32l4.c`: ST Microelectronics STM32L4, STM32G0, STM32G4
-
-Last Updated: Sep 6, 2022 (Partial update)
-
-As additions happen, you can update the firmware to profit from these additions.
-There is experimental support for Cortex-A (ARMv7-A architecture).  This is being used with success on Xilinx Zynq-7000 SoC (Dual-core Cortex-A9) and Raspberry Pi 2 (Quad-core Cortex-A7).
-
-
 ## Where can I get the hardware?
 
 The official Black Magic Probe hardware is available from multiple vendors. An up to date list is kept on the [project main page](index.md#getting-hardware).

--- a/supported-targets.md
+++ b/supported-targets.md
@@ -2,54 +2,64 @@
 
 ## Cortex-M
 
-Manufacturer      | Family      | Support Level | Version Introduced | Implemented In | Notes
-------------------|-------------|---------------|--------------------|----------------|------
-ST Micro          | STM32F0     | ✔ Full        | v1.6               | stm32f1.c      |
-ST Micro          | STM32F1     | ✔ Full        |                    | stm32f1.c      |
-ST Micro          | STM32F2     | ✔ Full        | v1.6               | stm32f4.c      |
-ST Micro          | STM32F3     | ✔ Full        | v1.6               | stm32f1.c      |
-ST Micro          | STM32F4     | ✔ Full        |                    | stm32f4.c      |
-ST Micro          | STM32F7     | ✔ Full        | v1.6               | stm32f4.c      |
-ST Micro          | STM32G0     | ✔ Full        | v1.8.0             | stm32g0.c      |
-ST Micro          | STM32G4     | ✔ Full        | v1.6.2             | stm32l4.c      |
-ST Micro          | STM32C0     | ✔ Full        | v1.10.0            | stm32g0.c      |
-ST Micro          | STM32H5     | ✔ Full        | v1.10.0            | stm32h5.c      |
-ST Micro          | STM32H7     | ✔ Full        | v1.8.0             | stm32h7.c      |
-ST Micro          | STM32L0     | ✔ Full        | v1.6               | stm32l0.c      |
-ST Micro          | STM32L1     | ✔ Full        | v1.6               | stm32l0.c      |
-ST Micro          | STM32L4     | ✔ Full        | pre-v1.6           | stm32l4.c      |
-ST Micro          | STM32L55    | ✔ Full        | v1.8.0             | stm32l4.c      |
-ST Micro          | STM32U5     | ✔ Full        | v1.10.0            | stm32l4.c      |
-ST Micro          | STM32WL     | ✔ Full        | v1.8.0             | stm32l4.c      |
-ST Micro          | STM32WB     | ✔ Full        | v1.8.0             | stm32l4.c      |
-GigaDevice        | GD32F1      | ✔ Full        | v1.8.0             | stm32f1.c      |
-GigaDevice        | GD32F2      | ✔ Full        | v1.10.0            | stm32f1.c      |
-GigaDevice        | GD32F3      | ✔ Full        | v1.8.0             | stm32f1.c      |
-GigaDevice        | GD32F4      | ✔ Full        | v1.10.0            | stm32f4.c      |
-GigaDevice        | GD32E230    | ✔ Full        |                    | stm32f1.c      |
-GigaDevice        | GD32E5      | ✔ Full        | v1.10.0            | stm32f1.c      |
-ArteryTek         | AT32F40     | ✔ Full        | v1.9.0             | stm32f1.c      |
-ArteryTek         | AT32F41     | ✔ Full        | v1.9.0             | stm32f1.c      |
-ArteryTek         | AT32F43     | ✔ Full        | v1.10.0            | stm32f1.c      |
-MindMotion        | MM32L0      | ✔ Full        | v1.10.0            | stm32f1.c      |
-MindMotion        | MM32SPIN    | ✔ Full        | v1.10.0            | stm32f1.c      |
-MindMotion        | MM32F3      | ✔ Full        | v1.10.0            | stm32f1.c      |
-MindMotion        | MM32F5      | ✔ Full        | v1.10.0            | stm32f1.c      |
-WinChipHead       | CH32F1      | ✔ Full        | v1.8.0             | ch32f1.c       |
-Texas Instruments | LM3S        | ✔ Full        |                    | lmi.c          |
-Texas Instruments | LM4C/TM4C   | ✔ Full        | v1.6               | lmi.c          |
-Microchip         | ATSAM D5/E5 | ✔ Full        | v1.6.2             | samx5x.c       |
-Atmel             | ATSAM D     | ✔ Full        | v1.6               | samd.c         |
-Atmel             | ATSAM 4L    | ✔ Full        | v1.6               | sam4l.c        |
-Atmel             | ATSAM 3x    | ✔ Full        | v1.6               | sam3x.c        |
-RPi Foundation    | RP2040      | ✔ Full        | v1.8.0             | rp.c           |
-Renesas           | R7FA        |               | v1.9.0             | renesas.c      |
-Freescale         | KE04        | ✔ Full        |                    | nxpke04.c      |
-Nordic Semi       | nRF51       | ✔ Full        | v1.6               | nrf51.c        |
-Nordic Semi       | nRF52       | ✔ Full        | v1.6               | nrf51.c        |
-Nordic Semi       | nRF91       | ○ Partial     | v1.10.0            | nrf91.c        |
-Texas Instruments | MSP432P4    | ✔ Full        | v1.6.2             | msp432p4.c     |
-Texas Instruments | MSP432E4    | ✔ Full        | v1.0.0             | msp432e4.c     |
+|Manufacturer      | Family      | Support Level | Version Introduced | Implemented In | Notes
+|------------------|-------------|---------------|--------------------|----------------|------
+|ST Micro          | STM32F0     | ✔ Full        | v1.6               | stm32f1.c      |
+|ST Micro          | STM32F1     | ✔ Full        |                    | stm32f1.c      |
+|ST Micro          | STM32F2     | ✔ Full        | v1.6               | stm32f4.c      |
+|ST Micro          | STM32F3     | ✔ Full        | v1.6               | stm32f1.c      |
+|ST Micro          | STM32F4     | ✔ Full        |                    | stm32f4.c      |
+|ST Micro          | STM32F7     | ✔ Full        | v1.6               | stm32f4.c      |
+|ST Micro          | STM32G0     | ✔ Full        | v1.8.0             | stm32g0.c      |
+|ST Micro          | STM32G4     | ✔ Full        | v1.6.2             | stm32l4.c      |
+|ST Micro          | STM32C0     | ✔ Full        | v1.10.0            | stm32g0.c      |
+|ST Micro          | STM32H5     | ✔ Full        | v1.10.0            | stm32h5.c      |
+|ST Micro          | STM32H7     | ✔ Full        | v1.8.0             | stm32h7.c      |
+|ST Micro          | STM32L0     | ✔ Full        | v1.6               | stm32l0.c      |
+|ST Micro          | STM32L1     | ✔ Full        | v1.6               | stm32l0.c      |
+|ST Micro          | STM32L4     | ✔ Full        | pre-v1.6           | stm32l4.c      |
+|ST Micro          | STM32L55    | ✔ Full        | v1.8.0             | stm32l4.c      |
+|ST Micro          | STM32U5     | ✔ Full        | v1.10.0            | stm32l4.c      |
+|ST Micro          | STM32WL     | ✔ Full        | v1.8.0             | stm32l4.c      |
+|ST Micro          | STM32WB     | ✔ Full        | v1.8.0             | stm32l4.c      |
+|GigaDevice        | GD32F1      | ✔ Full        | v1.8.0             | stm32f1.c      |
+|GigaDevice        | GD32F2      | ✔ Full        | v1.10.0            | stm32f1.c      |
+|GigaDevice        | GD32F3      | ✔ Full        | v1.8.0             | stm32f1.c      |
+|GigaDevice        | GD32F4      | ✔ Full        | v1.10.0            | stm32f4.c      |
+|GigaDevice        | GD32E230    | ✔ Full        |                    | stm32f1.c      |
+|GigaDevice        | GD32E5      | ✔ Full        | v1.10.0            | stm32f1.c      |
+|ArteryTek         | AT32F40     | ✔ Full        | v1.9.0             | stm32f1.c      |
+|ArteryTek         | AT32F41     | ✔ Full        | v1.9.0             | stm32f1.c      |
+|ArteryTek         | AT32F43     | ✔ Full        | v1.10.0            | stm32f1.c      |
+|MindMotion        | MM32L0      | ✔ Full        | v1.10.0            | stm32f1.c      |
+|MindMotion        | MM32SPIN    | ✔ Full        | v1.10.0            | stm32f1.c      |
+|MindMotion        | MM32F3      | ✔ Full        | v1.10.0            | stm32f1.c      |
+|MindMotion        | MM32F5      | ✔ Full        | v1.10.0            | stm32f1.c      |
+|WinChipHead       | CH32F1      | ✔ Full        | v1.8.0             | ch32f1.c       |
+|Texas Instruments | LM3S        | ✔ Full        |                    | lmi.c          |
+|Texas Instruments | LM4C/TM4C   | ✔ Full        | v1.6               | lmi.c          |
+|Microchip         | ATSAM D5/E5 | ✔ Full        | v1.6.2             | samx5x.c       |
+|Atmel             | ATSAM D     | ✔ Full        | v1.6               | samd.c         |
+|Atmel             | ATSAM 4L    | ✔ Full        | v1.6               | sam4l.c        |
+|Atmel             | ATSAM 3x    | ✔ Full        | v1.6               | sam3x.c        |
+|RPi Foundation    | RP2040      | ✔ Full        | v1.8.0             | rp.c           |
+|Renesas           | R7FA        | ○ Partial     | v1.9.0             | renesas.c      |
+|Freescale         | KE04        | ✔ Full        |                    | nxpke04.c      |
+|Nordic Semi       | nRF51       | ✔ Full        | v1.6               | nrf51.c        |
+|Nordic Semi       | nRF52       | ✔ Full        | v1.6               | nrf51.c        |
+|Nordic Semi       | nRF91       | ○ Partial     | v1.10.0            | nrf91.c        |
+|Texas Instruments | MSP432P4    | ✔ Full        | v1.6.2             | msp432p4.c     |
+|Texas Instruments | MSP432E4    | ✔ Full        | v1.10.0            | msp432e4.c     |
+|NXP               | LPC546      | ✔ Full        | v1.8.0             | lpc546xx.c     |
+|NXP               | LPC55       | ✔ Full        | v1.10.0            | lpc55xx.c      |
+|NXP               | LPC43       | ✔ Full        | v1.6               | lpc43xx.c      | [^1]
+|NXP               | LPC40       | ✔ Full        | v1.10.0            | lpc40xx.c      |
+|NXP               | LPC17       | ✔ Full        | v1.6.2             | lpc17xx.c      |
+|NXP               | LPC15       | ✔ Full        | v1.6               | lpc15xx.c      |
+|NXP               | LPC8        | ✔ Full        | v1.6               | lpc11xx.c      |
+|NXP               | LPC11       | ✔ Full        | v1.6               | lpc11xx.c      |
+
+[^1]: LPC43x0 Flash support was added in v1.10.0.
 
 ✗
 

--- a/supported-targets.md
+++ b/supported-targets.md
@@ -43,7 +43,11 @@
 | Atmel             | ATSAM 4L    | ✔ Full        | v1.6               | sam4l.c        |
 | Atmel             | ATSAM 3x    | ✔ Full        | v1.6               | sam3x.c        |
 | RPi Foundation    | RP2040      | ✔ Full        | v1.8.0             | rp.c           |
-| Renesas           | R7FA        | ○ Partial     | v1.9.0             | renesas.c      |
+| Renesas           | R7FA        | ○ Partial     | v1.9.0             | renesas.c      | Unless specified below
+| Renesas           | R7FARA2A1   | ✗ Debug only  | v1.9.0             | renesas.c      |
+| Renesas           | R7FARA4M2   | ✔ Full        | v1.9.0             | renesas.c      |
+| Renesas           | R7FARA4M3   | ✔ Full        | v1.9.0             | renesas.c      |
+| Renesas           | R7FARA6M2   | ✔ Full        | v1.9.0             | renesas.c      |
 | Freescale         | KE04        | ✔ Full        | v1.6.2             | nxpke04.c      |
 | Nordic Semi       | nRF51       | ✔ Full        | v1.6               | nrf51.c        |
 | Nordic Semi       | nRF52       | ✔ Full        | v1.6               | nrf51.c        |
@@ -66,9 +70,14 @@
 | Freescale         | K12         | ✔ Full        | v1.8.0             | kinetis.c      |
 | Freescale         | K22F        | ✔ Full        | pre-v1.6           | kinetis.c      |
 | Freescale         | K64F        | ✔ Full        | v1.6.2             | kinetis.c      |
+| NXP               | S32K11      | ✔ Full        | v1.8.0             | kinetis.c      |
 | NXP               | S32K14      | ✔ Full        | v1.8.0             | kinetis.c      |
 | NXP               | i.MX RT10   | ✔ Full        | v1.10.0            | imxrt.c        |
+| NXP               | i.MX RT11   | ✗ Debug only  | v1.10.0            | imxrt.c        |
 | HDSC              | HD32L110    | ✔ Full        | v1.10.0            | hd32l110.c     |
+| Energy Micro      | EFM32       | ✔ Full        | v1.6               | efm32.c        |
+| Energy Micro      | EZR32       | ✔ Full        | v1.6               | efm32.c        |
+| Energy Micro      | EFR32       | ✔ Full        | v1.6.2             | efm32.c        |
 
 [^1]: LPC43x0 Flash support was added in v1.10.0.
 

--- a/supported-targets.md
+++ b/supported-targets.md
@@ -5,10 +5,10 @@
 | Manufacturer      | Family      | Support Level | Version Introduced | Implemented In | Notes
 |-------------------|-------------|---------------|--------------------|----------------|------
 | ST Micro          | STM32F0     | ✔ Full        | v1.6               | stm32f1.c      |
-| ST Micro          | STM32F1     | ✔ Full        |                    | stm32f1.c      |
+| ST Micro          | STM32F1     | ✔ Full        | pre-v1.6           | stm32f1.c      |
 | ST Micro          | STM32F2     | ✔ Full        | v1.6               | stm32f4.c      |
 | ST Micro          | STM32F3     | ✔ Full        | v1.6               | stm32f1.c      |
-| ST Micro          | STM32F4     | ✔ Full        |                    | stm32f4.c      |
+| ST Micro          | STM32F4     | ✔ Full        | pre-v1.6           | stm32f4.c      |
 | ST Micro          | STM32F7     | ✔ Full        | v1.6               | stm32f4.c      |
 | ST Micro          | STM32G0     | ✔ Full        | v1.8.0             | stm32g0.c      |
 | ST Micro          | STM32G4     | ✔ Full        | v1.6.2             | stm32l4.c      |
@@ -26,7 +26,7 @@
 | GigaDevice        | GD32F2      | ✔ Full        | v1.10.0            | stm32f1.c      |
 | GigaDevice        | GD32F3      | ✔ Full        | v1.8.0             | stm32f1.c      |
 | GigaDevice        | GD32F4      | ✔ Full        | v1.10.0            | stm32f4.c      |
-| GigaDevice        | GD32E230    | ✔ Full        |                    | stm32f1.c      |
+| GigaDevice        | GD32E230    | ✔ Full        | v1.8.0             | stm32f1.c      |
 | GigaDevice        | GD32E5      | ✔ Full        | v1.10.0            | stm32f1.c      |
 | ArteryTek         | AT32F40     | ✔ Full        | v1.9.0             | stm32f1.c      |
 | ArteryTek         | AT32F41     | ✔ Full        | v1.9.0             | stm32f1.c      |
@@ -36,7 +36,7 @@
 | MindMotion        | MM32F3      | ✔ Full        | v1.10.0            | stm32f1.c      |
 | MindMotion        | MM32F5      | ✔ Full        | v1.10.0            | stm32f1.c      |
 | WinChipHead       | CH32F1      | ✔ Full        | v1.8.0             | ch32f1.c       |
-| Texas Instruments | LM3S        | ✔ Full        |                    | lmi.c          |
+| Texas Instruments | LM3S        | ✔ Full        | pre-v1.6           | lmi.c          |
 | Texas Instruments | LM4C/TM4C   | ✔ Full        | v1.6               | lmi.c          |
 | Microchip         | ATSAM D5/E5 | ✔ Full        | v1.6.2             | samx5x.c       |
 | Atmel             | ATSAM D     | ✔ Full        | v1.6               | samd.c         |

--- a/supported-targets.md
+++ b/supported-targets.md
@@ -44,7 +44,7 @@
 | Atmel             | ATSAM 3x    | ✔ Full        | v1.6               | sam3x.c        |
 | RPi Foundation    | RP2040      | ✔ Full        | v1.8.0             | rp.c           |
 | Renesas           | R7FA        | ○ Partial     | v1.9.0             | renesas.c      |
-| Freescale         | KE04        | ✔ Full        |                    | nxpke04.c      |
+| Freescale         | KE04        | ✔ Full        | v1.6.2             | nxpke04.c      |
 | Nordic Semi       | nRF51       | ✔ Full        | v1.6               | nrf51.c        |
 | Nordic Semi       | nRF52       | ✔ Full        | v1.6               | nrf51.c        |
 | Nordic Semi       | nRF91       | ○ Partial     | v1.10.0            | nrf91.c        |
@@ -58,7 +58,17 @@
 | NXP               | LPC15       | ✔ Full        | v1.6               | lpc15xx.c      |
 | NXP               | LPC8        | ✔ Full        | v1.6               | lpc11xx.c      |
 | NXP               | LPC11       | ✔ Full        | v1.6               | lpc11xx.c      |
+| Freescale         | KL02        | ✔ Full        | pre-v1.6           | kinetis.c      |
+| Freescale         | KL03        | ✔ Full        | v1.6               | kinetis.c      |
+| Freescale         | KL16Z       | ✔ Full        | v1.6.2             | kinetis.c      |
+| Freescale         | KL25        | ✔ Full        | v1.6               | kinetis.c      |
+| Freescale         | KL27        | ✔ Full        | v1.6               | kinetis.c      |
+| Freescale         | K12         | ✔ Full        | v1.8.0             | kinetis.c      |
+| Freescale         | K22F        | ✔ Full        | pre-v1.6           | kinetis.c      |
+| Freescale         | K64F        | ✔ Full        | v1.6.2             | kinetis.c      |
+| NXP               | S32K14      | ✔ Full        | v1.8.0             | kinetis.c      |
 | NXP               | i.MX RT10   | ✔ Full        | v1.10.0            | imxrt.c        |
+| HDSC              | HD32L110    | ✔ Full        | v1.10.0            | hd32l110.c     |
 
 [^1]: LPC43x0 Flash support was added in v1.10.0.
 

--- a/supported-targets.md
+++ b/supported-targets.md
@@ -2,68 +2,69 @@
 
 ## Cortex-M
 
-|Manufacturer      | Family      | Support Level | Version Introduced | Implemented In | Notes
-|------------------|-------------|---------------|--------------------|----------------|------
-|ST Micro          | STM32F0     | ✔ Full        | v1.6               | stm32f1.c      |
-|ST Micro          | STM32F1     | ✔ Full        |                    | stm32f1.c      |
-|ST Micro          | STM32F2     | ✔ Full        | v1.6               | stm32f4.c      |
-|ST Micro          | STM32F3     | ✔ Full        | v1.6               | stm32f1.c      |
-|ST Micro          | STM32F4     | ✔ Full        |                    | stm32f4.c      |
-|ST Micro          | STM32F7     | ✔ Full        | v1.6               | stm32f4.c      |
-|ST Micro          | STM32G0     | ✔ Full        | v1.8.0             | stm32g0.c      |
-|ST Micro          | STM32G4     | ✔ Full        | v1.6.2             | stm32l4.c      |
-|ST Micro          | STM32C0     | ✔ Full        | v1.10.0            | stm32g0.c      |
-|ST Micro          | STM32H5     | ✔ Full        | v1.10.0            | stm32h5.c      |
-|ST Micro          | STM32H7     | ✔ Full        | v1.8.0             | stm32h7.c      |
-|ST Micro          | STM32L0     | ✔ Full        | v1.6               | stm32l0.c      |
-|ST Micro          | STM32L1     | ✔ Full        | v1.6               | stm32l0.c      |
-|ST Micro          | STM32L4     | ✔ Full        | pre-v1.6           | stm32l4.c      |
-|ST Micro          | STM32L55    | ✔ Full        | v1.8.0             | stm32l4.c      |
-|ST Micro          | STM32U5     | ✔ Full        | v1.10.0            | stm32l4.c      |
-|ST Micro          | STM32WL     | ✔ Full        | v1.8.0             | stm32l4.c      |
-|ST Micro          | STM32WB     | ✔ Full        | v1.8.0             | stm32l4.c      |
-|GigaDevice        | GD32F1      | ✔ Full        | v1.8.0             | stm32f1.c      |
-|GigaDevice        | GD32F2      | ✔ Full        | v1.10.0            | stm32f1.c      |
-|GigaDevice        | GD32F3      | ✔ Full        | v1.8.0             | stm32f1.c      |
-|GigaDevice        | GD32F4      | ✔ Full        | v1.10.0            | stm32f4.c      |
-|GigaDevice        | GD32E230    | ✔ Full        |                    | stm32f1.c      |
-|GigaDevice        | GD32E5      | ✔ Full        | v1.10.0            | stm32f1.c      |
-|ArteryTek         | AT32F40     | ✔ Full        | v1.9.0             | stm32f1.c      |
-|ArteryTek         | AT32F41     | ✔ Full        | v1.9.0             | stm32f1.c      |
-|ArteryTek         | AT32F43     | ✔ Full        | v1.10.0            | stm32f1.c      |
-|MindMotion        | MM32L0      | ✔ Full        | v1.10.0            | stm32f1.c      |
-|MindMotion        | MM32SPIN    | ✔ Full        | v1.10.0            | stm32f1.c      |
-|MindMotion        | MM32F3      | ✔ Full        | v1.10.0            | stm32f1.c      |
-|MindMotion        | MM32F5      | ✔ Full        | v1.10.0            | stm32f1.c      |
-|WinChipHead       | CH32F1      | ✔ Full        | v1.8.0             | ch32f1.c       |
-|Texas Instruments | LM3S        | ✔ Full        |                    | lmi.c          |
-|Texas Instruments | LM4C/TM4C   | ✔ Full        | v1.6               | lmi.c          |
-|Microchip         | ATSAM D5/E5 | ✔ Full        | v1.6.2             | samx5x.c       |
-|Atmel             | ATSAM D     | ✔ Full        | v1.6               | samd.c         |
-|Atmel             | ATSAM 4L    | ✔ Full        | v1.6               | sam4l.c        |
-|Atmel             | ATSAM 3x    | ✔ Full        | v1.6               | sam3x.c        |
-|RPi Foundation    | RP2040      | ✔ Full        | v1.8.0             | rp.c           |
-|Renesas           | R7FA        | ○ Partial     | v1.9.0             | renesas.c      |
-|Freescale         | KE04        | ✔ Full        |                    | nxpke04.c      |
-|Nordic Semi       | nRF51       | ✔ Full        | v1.6               | nrf51.c        |
-|Nordic Semi       | nRF52       | ✔ Full        | v1.6               | nrf51.c        |
-|Nordic Semi       | nRF91       | ○ Partial     | v1.10.0            | nrf91.c        |
-|Texas Instruments | MSP432P4    | ✔ Full        | v1.6.2             | msp432p4.c     |
-|Texas Instruments | MSP432E4    | ✔ Full        | v1.10.0            | msp432e4.c     |
-|NXP               | LPC546      | ✔ Full        | v1.8.0             | lpc546xx.c     |
-|NXP               | LPC55       | ✔ Full        | v1.10.0            | lpc55xx.c      |
-|NXP               | LPC43       | ✔ Full        | v1.6               | lpc43xx.c      | [^1]
-|NXP               | LPC40       | ✔ Full        | v1.10.0            | lpc40xx.c      |
-|NXP               | LPC17       | ✔ Full        | v1.6.2             | lpc17xx.c      |
-|NXP               | LPC15       | ✔ Full        | v1.6               | lpc15xx.c      |
-|NXP               | LPC8        | ✔ Full        | v1.6               | lpc11xx.c      |
-|NXP               | LPC11       | ✔ Full        | v1.6               | lpc11xx.c      |
+| Manufacturer      | Family      | Support Level | Version Introduced | Implemented In | Notes
+|-------------------|-------------|---------------|--------------------|----------------|------
+| ST Micro          | STM32F0     | ✔ Full        | v1.6               | stm32f1.c      |
+| ST Micro          | STM32F1     | ✔ Full        |                    | stm32f1.c      |
+| ST Micro          | STM32F2     | ✔ Full        | v1.6               | stm32f4.c      |
+| ST Micro          | STM32F3     | ✔ Full        | v1.6               | stm32f1.c      |
+| ST Micro          | STM32F4     | ✔ Full        |                    | stm32f4.c      |
+| ST Micro          | STM32F7     | ✔ Full        | v1.6               | stm32f4.c      |
+| ST Micro          | STM32G0     | ✔ Full        | v1.8.0             | stm32g0.c      |
+| ST Micro          | STM32G4     | ✔ Full        | v1.6.2             | stm32l4.c      |
+| ST Micro          | STM32C0     | ✔ Full        | v1.10.0            | stm32g0.c      |
+| ST Micro          | STM32H5     | ✔ Full        | v1.10.0            | stm32h5.c      |
+| ST Micro          | STM32H7     | ✔ Full        | v1.8.0             | stm32h7.c      |
+| ST Micro          | STM32L0     | ✔ Full        | v1.6               | stm32l0.c      |
+| ST Micro          | STM32L1     | ✔ Full        | v1.6               | stm32l0.c      |
+| ST Micro          | STM32L4     | ✔ Full        | pre-v1.6           | stm32l4.c      |
+| ST Micro          | STM32L55    | ✔ Full        | v1.8.0             | stm32l4.c      |
+| ST Micro          | STM32U5     | ✔ Full        | v1.10.0            | stm32l4.c      |
+| ST Micro          | STM32WL     | ✔ Full        | v1.8.0             | stm32l4.c      |
+| ST Micro          | STM32WB     | ✔ Full        | v1.8.0             | stm32l4.c      |
+| GigaDevice        | GD32F1      | ✔ Full        | v1.8.0             | stm32f1.c      |
+| GigaDevice        | GD32F2      | ✔ Full        | v1.10.0            | stm32f1.c      |
+| GigaDevice        | GD32F3      | ✔ Full        | v1.8.0             | stm32f1.c      |
+| GigaDevice        | GD32F4      | ✔ Full        | v1.10.0            | stm32f4.c      |
+| GigaDevice        | GD32E230    | ✔ Full        |                    | stm32f1.c      |
+| GigaDevice        | GD32E5      | ✔ Full        | v1.10.0            | stm32f1.c      |
+| ArteryTek         | AT32F40     | ✔ Full        | v1.9.0             | stm32f1.c      |
+| ArteryTek         | AT32F41     | ✔ Full        | v1.9.0             | stm32f1.c      |
+| ArteryTek         | AT32F43     | ✔ Full        | v1.10.0            | stm32f1.c      |
+| MindMotion        | MM32L0      | ✔ Full        | v1.10.0            | stm32f1.c      |
+| MindMotion        | MM32SPIN    | ✔ Full        | v1.10.0            | stm32f1.c      |
+| MindMotion        | MM32F3      | ✔ Full        | v1.10.0            | stm32f1.c      |
+| MindMotion        | MM32F5      | ✔ Full        | v1.10.0            | stm32f1.c      |
+| WinChipHead       | CH32F1      | ✔ Full        | v1.8.0             | ch32f1.c       |
+| Texas Instruments | LM3S        | ✔ Full        |                    | lmi.c          |
+| Texas Instruments | LM4C/TM4C   | ✔ Full        | v1.6               | lmi.c          |
+| Microchip         | ATSAM D5/E5 | ✔ Full        | v1.6.2             | samx5x.c       |
+| Atmel             | ATSAM D     | ✔ Full        | v1.6               | samd.c         |
+| Atmel             | ATSAM 4L    | ✔ Full        | v1.6               | sam4l.c        |
+| Atmel             | ATSAM 3x    | ✔ Full        | v1.6               | sam3x.c        |
+| RPi Foundation    | RP2040      | ✔ Full        | v1.8.0             | rp.c           |
+| Renesas           | R7FA        | ○ Partial     | v1.9.0             | renesas.c      |
+| Freescale         | KE04        | ✔ Full        |                    | nxpke04.c      |
+| Nordic Semi       | nRF51       | ✔ Full        | v1.6               | nrf51.c        |
+| Nordic Semi       | nRF52       | ✔ Full        | v1.6               | nrf51.c        |
+| Nordic Semi       | nRF91       | ○ Partial     | v1.10.0            | nrf91.c        |
+| Texas Instruments | MSP432P4    | ✔ Full        | v1.6.2             | msp432p4.c     |
+| Texas Instruments | MSP432E4    | ✔ Full        | v1.10.0            | msp432e4.c     |
+| NXP               | LPC546      | ✔ Full        | v1.8.0             | lpc546xx.c     |
+| NXP               | LPC55       | ✔ Full        | v1.10.0            | lpc55xx.c      |
+| NXP               | LPC43       | ✔ Full        | v1.6               | lpc43xx.c      | [^1]
+| NXP               | LPC40       | ✔ Full        | v1.10.0            | lpc40xx.c      |
+| NXP               | LPC17       | ✔ Full        | v1.6.2             | lpc17xx.c      |
+| NXP               | LPC15       | ✔ Full        | v1.6               | lpc15xx.c      |
+| NXP               | LPC8        | ✔ Full        | v1.6               | lpc11xx.c      |
+| NXP               | LPC11       | ✔ Full        | v1.6               | lpc11xx.c      |
+| NXP               | i.MX RT10   | ✔ Full        | v1.10.0            | imxrt.c        |
 
 [^1]: LPC43x0 Flash support was added in v1.10.0.
 
 ## Cortex-A
 
-|Manufacturer      | Family      | Support Level | Version Introduced | Implemented In | Notes
-|------------------|-------------|---------------|--------------------|----------------|------
-| Xilinx           | Zynq        | ✗ Debug only  | v1.6               | cortexa.c      |
-| Broadcom         | BCM2836     | ✗ Debug only  | v1.6               | cortexa.c      |
+| Manufacturer      | Family      | Support Level | Version Introduced | Implemented In | Notes
+|-------------------|-------------|---------------|--------------------|----------------|------
+| Xilinx            | Zynq        | ✗ Debug only  | v1.6               | cortexa.c      |
+| Broadcom          | BCM2836     | ✗ Debug only  | v1.6               | cortexa.c      |

--- a/supported-targets.md
+++ b/supported-targets.md
@@ -61,6 +61,9 @@
 
 [^1]: LPC43x0 Flash support was added in v1.10.0.
 
-✗
-
 ## Cortex-A
+
+|Manufacturer      | Family      | Support Level | Version Introduced | Implemented In | Notes
+|------------------|-------------|---------------|--------------------|----------------|------
+| Xilinx           | Zynq        | ✗ Debug only  | v1.6               | cortexa.c      |
+| Broadcom         | BCM2836     | ✗ Debug only  | v1.6               | cortexa.c      |

--- a/supported-targets.md
+++ b/supported-targets.md
@@ -1,0 +1,56 @@
+# Supported Targets
+
+## Cortex-M
+
+Manufacturer      | Family      | Support Level | Version Introduced | Implemented In | Notes
+------------------|-------------|---------------|--------------------|----------------|------
+ST Micro          | STM32F0     | ✔ Full        | v1.6               | stm32f1.c      |
+ST Micro          | STM32F1     | ✔ Full        |                    | stm32f1.c      |
+ST Micro          | STM32F2     | ✔ Full        | v1.6               | stm32f4.c      |
+ST Micro          | STM32F3     | ✔ Full        | v1.6               | stm32f1.c      |
+ST Micro          | STM32F4     | ✔ Full        |                    | stm32f4.c      |
+ST Micro          | STM32F7     | ✔ Full        | v1.6               | stm32f4.c      |
+ST Micro          | STM32G0     | ✔ Full        | v1.8.0             | stm32g0.c      |
+ST Micro          | STM32G4     | ✔ Full        | v1.6.2             | stm32l4.c      |
+ST Micro          | STM32C0     | ✔ Full        | v1.10.0            | stm32g0.c      |
+ST Micro          | STM32H5     | ✔ Full        | v1.10.0            | stm32h5.c      |
+ST Micro          | STM32H7     | ✔ Full        | v1.8.0             | stm32h7.c      |
+ST Micro          | STM32L0     | ✔ Full        | v1.6               | stm32l0.c      |
+ST Micro          | STM32L1     | ✔ Full        | v1.6               | stm32l0.c      |
+ST Micro          | STM32L4     | ✔ Full        | pre-v1.6           | stm32l4.c      |
+ST Micro          | STM32L55    | ✔ Full        | v1.8.0             | stm32l4.c      |
+ST Micro          | STM32U5     | ✔ Full        | v1.10.0            | stm32l4.c      |
+ST Micro          | STM32WL     | ✔ Full        | v1.8.0             | stm32l4.c      |
+ST Micro          | STM32WB     | ✔ Full        | v1.8.0             | stm32l4.c      |
+GigaDevice        | GD32F1      | ✔ Full        | v1.8.0             | stm32f1.c      |
+GigaDevice        | GD32F2      | ✔ Full        | v1.10.0            | stm32f1.c      |
+GigaDevice        | GD32F3      | ✔ Full        | v1.8.0             | stm32f1.c      |
+GigaDevice        | GD32F4      | ✔ Full        | v1.10.0            | stm32f4.c      |
+GigaDevice        | GD32E230    | ✔ Full        |                    | stm32f1.c      |
+GigaDevice        | GD32E5      | ✔ Full        | v1.10.0            | stm32f1.c      |
+ArteryTek         | AT32F40     | ✔ Full        | v1.9.0             | stm32f1.c      |
+ArteryTek         | AT32F41     | ✔ Full        | v1.9.0             | stm32f1.c      |
+ArteryTek         | AT32F43     | ✔ Full        | v1.10.0            | stm32f1.c      |
+MindMotion        | MM32L0      | ✔ Full        | v1.10.0            | stm32f1.c      |
+MindMotion        | MM32SPIN    | ✔ Full        | v1.10.0            | stm32f1.c      |
+MindMotion        | MM32F3      | ✔ Full        | v1.10.0            | stm32f1.c      |
+MindMotion        | MM32F5      | ✔ Full        | v1.10.0            | stm32f1.c      |
+WinChipHead       | CH32F1      | ✔ Full        | v1.8.0             | ch32f1.c       |
+Texas Instruments | LM3S        | ✔ Full        |                    | lmi.c          |
+Texas Instruments | LM4C/TM4C   | ✔ Full        | v1.6               | lmi.c          |
+Microchip         | ATSAM D5/E5 | ✔ Full        | v1.6.2             | samx5x.c       |
+Atmel             | ATSAM D     | ✔ Full        | v1.6               | samd.c         |
+Atmel             | ATSAM 4L    | ✔ Full        | v1.6               | sam4l.c        |
+Atmel             | ATSAM 3x    | ✔ Full        | v1.6               | sam3x.c        |
+RPi Foundation    | RP2040      | ✔ Full        | v1.8.0             | rp.c           |
+Renesas           | R7FA        |               | v1.9.0             | renesas.c      |
+Freescale         | KE04        | ✔ Full        |                    | nxpke04.c      |
+Nordic Semi       | nRF51       | ✔ Full        | v1.6               | nrf51.c        |
+Nordic Semi       | nRF52       | ✔ Full        | v1.6               | nrf51.c        |
+Nordic Semi       | nRF91       | ○ Partial     | v1.10.0            | nrf91.c        |
+Texas Instruments | MSP432P4    | ✔ Full        | v1.6.2             | msp432p4.c     |
+Texas Instruments | MSP432E4    | ✔ Full        | v1.0.0             | msp432e4.c     |
+
+✗
+
+## Cortex-A


### PR DESCRIPTION
This PR defines a table of all the supported targets, what files implement the support, and what version of the firmware the support was introduced. This complements the index page supported targets graphic and replaces the target support FAQ.

We've also taken the liberty to sort out the FAQ section on the udev rules for Linux.