### PR TITLE
Feature: Xilinx 14pin

### DIFF
--- a/_pinouts/xilinx-14/data.py
+++ b/_pinouts/xilinx-14/data.py
@@ -7,8 +7,6 @@ legend = [
     ("Not Connected", "nc"),
 ]
 
-
-
 left_header = [
     [
         ("14", "pin"),

--- a/_pinouts/xilinx-14/data.py
+++ b/_pinouts/xilinx-14/data.py
@@ -1,0 +1,83 @@
+legend = [
+    ("JTAG", "jtag"),
+    ("Reset", "rst"),
+    ("Pin Number", "pin"),
+    ("Power", "pwr"),
+    ("Ground", "gnd"),
+    ("Not Connected", "nc"),
+]
+
+
+
+left_header = [
+    [
+        ("14", "pin"),
+        ("nRST", "rst")
+    ],
+    [
+        ("12", "pin"),
+        ("NC", "nc")
+    ],
+    [
+        ("10", "pin"),
+        ("TDI", "jtag")
+    ],
+    [
+        ("8", "pin"),
+        ("TDO", "jtag")
+    ],
+    [
+        ("6", "pin"),
+        ("TCK", "jtag")
+    ],
+    [
+        ("4", "pin"),
+        ("TMS", "jtag")
+    ],
+    [
+        ("2", "pin"),
+        ("vRef", "pwr")
+    ],
+]
+
+right_header = [
+    [
+        ("13", "pin"),
+        ("GND", "gnd")
+    ],
+    [
+        ("11", "pin"),
+        ("GND", "gnd")
+    ],
+    [
+        ("9", "pin"),
+        ("GND", "gnd")
+    ],
+    [
+        ("7", "pin"),
+        ("GND", "gnd")
+    ],
+    [
+        ("5", "pin"),
+        ("GND", "gnd")
+    ],
+    [
+        ("3", "pin"),
+        ("GND", "gnd")
+    ],
+    [
+        ("1", "pin"),
+        ("NC", "nc")
+    ],
+]
+
+# Text
+
+title = "<tspan class='h1'>Xilinx JTAG Debug Connector Pinout</tspan>"
+
+description = """This is the debug connector Xilinx came up with,
+it is used on a majority of Xilinx boards for test and debug, especially
+the Zynq and Kria SoCs.
+
+<tspan class='strong'>NOTE:</tspan> The header is METRIC! It's a 2mm pin pitch.
+"""

--- a/_pinouts/xilinx-14/pinout_diagram.py
+++ b/_pinouts/xilinx-14/pinout_diagram.py
@@ -1,0 +1,117 @@
+from tkinter import Scale
+from pinout import config
+from pinout.core import Group, Image
+from pinout.components.layout import Diagram_2Rows, Panel
+from pinout.components.pinlabel import PinLabelGroup
+from pinout.components.annotation import AnnotationLabel
+from pinout.components.text import TextBlock
+from pinout.components import leaderline as lline
+from pinout.components.legend import Legend
+
+import data
+
+diagram = Diagram_2Rows(800, 550, 300, "diagram")
+diagram.add_stylesheet("styles.css", embed=True)
+
+# panel_graphic = content.add(
+#     Panel(
+#         width=860,
+#         height=300,
+#         tag="panel__graphic",
+#     )
+# )
+
+graphic = diagram.panel_01.add(Group(320, 20))
+
+hardware = graphic.add(Image("../models/14-pin-keyed.svg", width=180, height=270, embed=True))
+
+hardware.add_coord("p14", x= 75, y= 45)
+hardware.add_coord("p13", x=105, y= 45)
+hardware.add_coord("p12", x= 75, y= 75)
+hardware.add_coord("p11", x=105, y= 75)
+hardware.add_coord("p10", x= 75, y=105)
+hardware.add_coord("p9",  x=105, y=105)
+hardware.add_coord("p8",  x= 75, y=135)
+hardware.add_coord("p7",  x=105, y=135)
+hardware.add_coord("p6",  x= 75, y=165)
+hardware.add_coord("p5",  x=105, y=165)
+hardware.add_coord("p4",  x= 75, y=195)
+hardware.add_coord("p3",  x=105, y=195)
+hardware.add_coord("p2",  x= 75, y=215)
+hardware.add_coord("p1",  x=105, y=215)
+hardware.add_coord("pin_pitch_v", x=0, y=30)
+
+graphic.add(
+    PinLabelGroup(
+        x=hardware.coord("p14").x,
+        y=hardware.coord("p14").y,
+        pin_pitch=hardware.coord("pin_pitch_v", raw=True),
+        label_start=(60, 0),
+        label_pitch=(0, 30),
+        scale=(-1, 1),
+        labels=data.left_header,
+    )
+)
+
+graphic.add(
+    PinLabelGroup(
+        x=hardware.coord("p13").x,
+        y=hardware.coord("p13").y,
+        pin_pitch=hardware.coord("pin_pitch_v", raw=True),
+        label_start=(60, 0),
+        label_pitch=(0, 30),
+        labels=data.right_header,
+    )
+)
+
+# Create a title and description text-blocks
+title_block = diagram.panel_02.add(
+    TextBlock(
+        data.title,
+        x=20,
+        y=30,
+        line_height=18,
+        tag="panel title_block",
+    )
+)
+diagram.panel_02.add(
+    TextBlock(
+        data.description,
+        x=20,
+        y=60,
+        width=title_block.width,
+        height=diagram.panel_02.height - title_block.height,
+        line_height=18,
+        tag="panel text_block",
+    )
+)
+
+
+# Create a legend
+legend = diagram.panel_02.add(
+    Legend(
+        data.legend,
+        x=630,
+        y=8,
+        max_height=230,
+    )
+)
+
+license = diagram.panel_02.add(Group(x=20, y=200))
+
+license.add(
+    Image("../models/by-nc-sa.svg", embed=True)
+)
+
+license.add(
+    TextBlock(
+        """2023 (C) 1BitSquared &lt;info@1bitsquared.com&gt;
+        2023 (C) Aki Van Ness &lt;aki@lethalbit.net&gt;""",
+        x=130,
+        y=20,
+        width=100,
+        height=30,
+        line_height=18,
+        tag="panel license",
+    )
+)

--- a/_pinouts/xilinx-14/styles.css
+++ b/_pinouts/xilinx-14/styles.css
@@ -1,0 +1,136 @@
+text {
+    font-family: Verdana, Georgia, sans-serif;
+    font-size: 14px;
+    font-weight: normal;
+}
+
+.pinlabel__leader{
+    stroke-width: 2;
+    fill: none;
+}
+
+.pinlabel__text{
+    dominant-baseline: central;
+    fill: #fff;
+    font-weight: bold;
+    stroke-width: 0;
+    text-anchor: middle;
+}
+
+.pwr .pinlabel__body{
+    fill: #C1292E;
+    stroke: rgb(0, 0, 0);
+}
+.pwr .pinlabel__leader{
+    stroke: #C1292E;
+}
+.pwr .swatch__body {
+    fill: #C1292E;
+    stroke: rgb(0, 0, 0);
+}
+.swd .pinlabel__body{
+    fill: #E89005;
+    stroke: rgb(0, 0, 0);
+}
+.swd .pinlabel__leader{
+    stroke: #E89005;
+}
+.swd .swatch__body {
+    fill: #E89005;
+    stroke: rgb(0, 0, 0);
+}
+.jtag .pinlabel__body{
+    fill: #2B59C3;
+    stroke: rgb(0, 0, 0);
+}
+.jtag .pinlabel__leader{
+    stroke: #2B59C3;
+}
+.jtag .swatch__body {
+    fill: #2B59C3;
+    stroke: rgb(0, 0, 0);
+}
+.uart .pinlabel__body{
+    fill: #4E148C;
+    stroke: rgb(0, 0, 0);
+}
+.uart .pinlabel__leader{
+    stroke: #4E148C;
+}
+.uart .swatch__body {
+    fill: #4E148C;
+    stroke: rgb(0, 0, 0);
+}
+.pin .pinlabel__body{
+    fill: #95B2B0;
+    stroke: rgb(0, 0, 0);
+}
+.pin .pinlabel__leader{
+    stroke: #95B2B0;
+}
+.pin .swatch__body {
+    fill: #95B2B0;
+    stroke: rgb(0, 0, 0);
+}
+.gnd .pinlabel__body{
+    fill: #210203;
+    stroke: rgb(0, 0, 0);
+}
+.gnd .pinlabel__leader{
+    stroke: #210203;
+}
+.gnd .swatch__body {
+    fill: #210203;
+}
+.rst .pinlabel__body{
+    fill: #E5F4E3;
+    stroke: rgb(0, 0, 0);
+}
+.rst .pinlabel__text{
+    fill: rgb(0, 0, 0);
+}
+.rst .pinlabel__leader{
+    stroke: #E5F4E3;
+}
+.rst .swatch__body {
+    fill: #E5F4E3;
+    stroke: rgb(0, 0, 0);
+}
+.nc .pinlabel__body{
+    fill: rgb(90, 90, 90);
+    stroke: rgb(0, 0, 0);
+}
+.nc .pinlabel__leader{
+    stroke: rgb(90, 90, 90);
+}
+.nc .swatch__body {
+    fill: rgb(90, 90, 90);
+    stroke: rgb(0, 0, 0);
+}
+
+.panel__inner {
+    fill: #fff;
+}
+.panel__outer {
+    fill: #333;
+}
+
+.legendentry text {
+    dominant-baseline: central;
+}
+
+.h1 {
+    font-size: 26px;
+    font-weight: bold;
+    font-style: italic;
+}
+.italic{
+    font-style: italic;
+}
+.strong{
+    font-weight: bold;
+}
+
+.panel--info .panel__inner{
+    fill: #f4f4f4;
+}

--- a/knowledge/pinouts.md
+++ b/knowledge/pinouts.md
@@ -61,3 +61,10 @@ SEGGER J-Link probes using this connector can interface directly with targets us
 ```{note}
 In both cases the adapter board does not allow for UART or J-Link Kickstart power (pin 19) to be used.
 ```
+
+## Xilinx 14pin Debug Connector
+
+![](../_pinouts/xilinx-14-legend.svg)
+
+This is a custom connector used on Xilinx boards, most notably ones with their SoC, MPSoC, and RFSoC
+devices for allowing access to the embedded ARM cores on the JTAG scan chain.


### PR DESCRIPTION
This PR adds the pinout for the Xilinx 14-pin JTAG connector that is found on all of their dev boards, this is especially useful for boards with their SoC, MPSoC, and RFSoC devices as the embedded ARM cores are on the same scan-chain and thus hooked up to the same connector.
