### PR TITLE
Fix: Windows build typos

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -9,7 +9,7 @@ If you don't have one already, you'll need to [get a Black Magic Probe](index.md
 Connect the Black Magic Probe to your computer's USB port. When connected via USB, the Black Magic Probe will
 enumerate as, among other bits, a pair of CDC-ACM (USB serial) devices.
 
-On Linux, the the OS should present these as `ttyACM` devices. On macOS they should be presented as pairs of `tty.`
+On Linux, the OS should present these as `ttyACM` devices. On macOS they should be presented as pairs of `tty.`
 and `cu.` devices, and on Windows they should be presented as a pair of COM ports.
 
 On Linux you can check the kernel log to find the device that was allocated:

--- a/knowledge/compiling-windows.md
+++ b/knowledge/compiling-windows.md
@@ -42,8 +42,10 @@ run the final line of this setup on each new shell you use.
 
 ### Acquiring the source
 
-You have a choice at this point - of either grabbing down a release from the project's GitHub repositories, or
-cloning the main repository.
+You have a choice at this point:
+
+* of either grabbing down a release from the project's GitHub repositories, or
+* cloning the main repository.
 
 #### From release Zip file
 

--- a/knowledge/compiling-windows.md
+++ b/knowledge/compiling-windows.md
@@ -59,8 +59,8 @@ You can then extract this file in a usable form by running:
 unzip $USERPROFILE/Downloads/blackmagic.zip
 ```
 
-This will make a directory of the source tree named per the release - for example, for v1.10.0-rc0, it makes
-the directory `blackmagic-1.10.0-rc0`. You will then need to change directory into this, eg:
+This will make a directory of the source tree named following the release's version string - for example,
+for v1.10.0-rc0 the directory is named `blackmagic-1.10.0-rc0`. You will then need to change directory into this, eg:
 
 ```bash
 cd blackmagic-1.10.0-rc0

--- a/knowledge/compiling-windows.md
+++ b/knowledge/compiling-windows.md
@@ -15,7 +15,7 @@ To build the firmware on Windows you will need the following minimum requirement
 * A POSIX-compliant shell such as Bash
 * Git for Windows, if building from the repository instead of a release
 
-The easiest way to get  to a working setup is to use:
+The easiest way to get to a working setup is to use:
 
 * [MSYS2](https://www.msys2.org/) and follow the installation guide
 * [ARM GNU Toolchain release 12.2.Rel1](https://developer.arm.com/-/media/Files/downloads/gnu/12.2.rel1/binrel/arm-gnu-toolchain-12.2.rel1-mingw-w64-i686-arm-none-eabi.zip?rev=709f3f15b2ee4763b186c10153ee6ca9&hash=8C0761A17A1E4861B96DDB604C177F5B)

--- a/knowledge/compiling-windows.md
+++ b/knowledge/compiling-windows.md
@@ -50,7 +50,7 @@ You have a choice at this point:
 #### From release Zip file
 
 If you want to use a release, visit [the project release index](https://github.com/blackmagic-debug/blackmagic/releases)
-and download the "Source code (zip)" entry's file from the release's assets, placing the file in your downloads as
+and download the "Source code (zip)" entry's file from the release's assets, saving the file in your downloads as
 `blackmagic.zip`.
 
 You can then extract this file in a usable form by running:

--- a/knowledge/compiling-windows.md
+++ b/knowledge/compiling-windows.md
@@ -13,7 +13,7 @@ To build the firmware on Windows you will need the following minimum requirement
 
 * The [ARM GNU Toolchain](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads) compiler suite for bare metal
 * A POSIX-compliant shell such as Bash
-* Git for Windows if building from the repository instead of a release
+* Git for Windows, if building from the repository instead of a release
 
 The easiest way to get  to a working setup is to use:
 


### PR DESCRIPTION
With thanks to @amyspark for giving the new Windows guide a read over and pointing out some mistakes we'd made, this PR fixes some spelling, wording and funky grammar in the guide as a follow-up to #40