### PR TITLE
Fix: Guide errors

### DIFF
--- a/knowledge/compiling-windows.md
+++ b/knowledge/compiling-windows.md
@@ -30,7 +30,7 @@ Inside the MSYS2 environment run the following to update the environment and fol
 
 ```bash
 pacman -Syu
-pacman -S pacboy git unzip
+pacman -S pactools git unzip
 pacboy -S python:p make:p
 unzip $USERPROFILE/Downloads/arm-gnu-toolchain-12.2.rel1-mingw-w64-i686-arm-none-eabi.zip -d .
 export PATH=$HOME/arm-gnu-toolchain-12.2.rel1-mingw-w64-i686-arm-none-eabi/bin:$PATH

--- a/usage/swo.md
+++ b/usage/swo.md
@@ -114,3 +114,9 @@ scripts for target setup. Run `orbuculum` to start collecting trace data. (All O
 for ITM data and predecessor to Orbuculum. (Linux-only. Command line driven)
 * [bmtrace](https://github.com/compuphase/Black-Magic-Probe-Book) - Basic ITM stream viewer. Configures BMD and tries
 to configure your target for you. Windows binaries available. (Windows and Linux only. Graphical)
+
+## Halting SWO recovery
+
+If you wish to stop recovery of SWO, decoding of ITM data, or need to get the firmware to resynchronise with your
+target, you can run `monitor traceswo disable` to spin the SWO engine down. Note, this frees any buffers associated
+with the SWO data recovery and resets state. This is required if you wish to scan for targets over JTAG.


### PR DESCRIPTION
In this PR we fix errors in the Compiling on Windows and SWO guides with thanks to Discord users 
lodwad and bivin.mato for pointing these issues out.

In the Compiling on Windows guide, the wrong package was named for the tool `pacboy`.

In the SWO usage guide, various links such as to the project's driver helper tree were stale and the instructions out of date against the current `main` firmware. The guide has been overhauled for spelling, grammar and punctuation in addition to the updates to correct the stale links and for the firmware.

We probably need a version of the SWO guide for v1.10 and previous, and the subject of how to go about documenting multiple firmware versions talked about. We feel that is not the place for this PR and that it needs some discussion.