### PR TITLE
usage/stm32cubeide: Add missing backtick

### DIFF
--- a/usage/stm32cubeide.md
+++ b/usage/stm32cubeide.md
@@ -53,7 +53,7 @@ STM32CubeIDE doesn't support hardware GDB run configurations.
 
 In order to support it, duplicate the `BMP Debug` configuration into `BMP Run`.
 
-In the Startup` tab, enter the following information for the `Run Commands`:
+In the `Startup` tab, enter the following information for the `Run Commands`:
 
 ```
 detach


### PR DESCRIPTION
Removed one too many backtick in #46 .
This causes a display error.

![image](https://github.com/user-attachments/assets/c0d8a336-c2d4-4d31-bc20-7663c9e38c07)

Fixed:

![image](https://github.com/user-attachments/assets/cfe327e6-3a67-4e1d-bc38-893ffd3904a5)
