### PR TITLE
Fix: Build restrictions clarifications

### DIFF
--- a/knowledge/bmputil-on-windows.md
+++ b/knowledge/bmputil-on-windows.md
@@ -39,6 +39,10 @@ rustup target add aarch64-pc-windows-msvc
    path the installer chooses (you can do it to a different one but will have to adjust the path for the environment
    in the build steps below).
 
+**NB:** Please note that environments like MSYS2 and Cygwin cannot be used for this. They provide their own `rustup`,
+and cannot run the launch scripts for the MSVC toolchain, thus resulting in being closer to the cross-compilation
+steps below. You must use either the cmd.exe shell or PowerShell to successfully complete these steps.
+
 ## Building `bmputil`
 
 The following instructions must be executed either from in a shell that used the "Developer Command Prompt" launcher


### PR DESCRIPTION
In this PR we provide some additional clarifying notes and advice in the `bmputil` build guide to allow users to make better informed decisions on how to proceed.

This includes a note about the shells that need to be used for a successfull native build.